### PR TITLE
Fix sendKeyCommand when multiple editors are instantiated

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -868,15 +868,17 @@ textAngular.service('textAngularManager', ['taToolExecuteAction', 'taTools', 'ta
 		},
 		// this is used by taBind to send a key command in response to a special key event
 		sendKeyCommand: function(scope, event){
-			angular.forEach(editors, function(_editor){
+			Object.keys(editors).forEach(function (key) {
 				/* istanbul ignore else: if nothing to do, do nothing */
-				if (_editor.editorFunctions.sendKeyCommand(event)){
-					/* istanbul ignore else: don't run if already running */
-					if(!scope._bUpdateSelectedStyles){
-						scope.updateSelectedStyles();
+				if (scope._name == key) {
+					if (editors[key].editorFunctions.sendKeyCommand(event)){
+						/* istanbul ignore else: don't run if already running */
+						if(!scope._bUpdateSelectedStyles){
+							scope.updateSelectedStyles();
+						}
+						event.preventDefault();
+						return false;
 					}
-					event.preventDefault();
-					return false;
 				}
 			});
 		}


### PR DESCRIPTION
Ran into this issue for my project.  A keypress was activated as many times as there were instantiated editors.   Ex: Two editors open.  Attempt to indent in editor 1, and two keypress execute, indenting twice instead of once.  

Kind of strange that this bug exists, and perhaps I have a scoping issue?  Regardless, it solved my issue.  Please let me know if this was my fault, and this fix is not essential.  Thanks.